### PR TITLE
Enable configurability of KAFKA_HEAP_OPTS, KAFKA_JMX_OPTS, and JMX_PORT

### DIFF
--- a/templates/kafka-broker.env.j2
+++ b/templates/kafka-broker.env.j2
@@ -1,2 +1,11 @@
 KAFKA_ZK_CONNECT="{{kafka_zk_connect}}"
 KAFKA_BROKER_CONNECT="{{kafka_broker_connect}}"
+{% if kafka_heap_opts is defined %}
+KAFKA_HEAP_OPTS="{{kafka_heap_opts}}"
+{% endif %}
+{% if kafka_jmx_opts is defined %}
+KAFKA_JMX_OPTS="{{kafka_jmx_opts}}"
+{% endif %}
+{% if kafka_jmx_port is defined %}
+JMX_PORT={{kafka_jmx_port}}
+{% endif %}

--- a/templates/kafka-broker.sh.j2
+++ b/templates/kafka-broker.sh.j2
@@ -1,2 +1,11 @@
 export KAFKA_ZK_CONNECT="{{kafka_zk_connect}}"
 export KAFKA_BROKER_CONNECT="{{kafka_broker_connect}}"
+{% if kafka_heap_opts is defined %}
+export KAFKA_HEAP_OPTS="{{kafka_heap_opts}}"
+{% endif %}
+{% if kafka_jmx_opts is defined %}
+export KAFKA_JMX_OPTS="{{kafka_jmx_opts}}"
+{% endif %}
+{% if kafka_jmx_port is defined %}
+export JMX_PORT={{kafka_jmx_port}}
+{% endif %}


### PR DESCRIPTION
Configurability of these environment variables enables use cases such as:
* `KAFKA_HEAP_OPTS` : JVM heap allocation other than default 1GB
* `KAFKA_JMX_OPTS` : optional introduction of things like jolokia agent
* `JMX_PORT` : monitoring via JMX